### PR TITLE
improve bonus node and core accounting

### DIFF
--- a/backend/bobmon.py
+++ b/backend/bobmon.py
@@ -317,6 +317,12 @@ def get_core_usage(data):
         if job['state'] == 'RUNNING':
             usage['running'] += job['nCpus']
 
+            # if job is running on a bonus node then add the bonus node to avail
+            for hostname in job['layout']:
+                node = data['nodes'][hostname]
+                if not node['isCounted']:
+                    usage['avail'] += node['nCpus']
+
     return usage
 
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -319,6 +319,14 @@ class App extends React.Component {
             }
         }
 
+        // if a "bonus" node us being wholy or partially used then count it as avail
+        for (let host in runningNodeList) {
+            if (!(nodes[host].isCounted)) {
+                usage.availCores += nodes[host].nCpus;
+                usage.availNodes += 1;
+            }
+        }
+
         for (let host in nodeFreeCores) {
           const count = nodeFreeCores[host]
           if (!(usage.freeCores.hasOwnProperty(count))) {


### PR DESCRIPTION
the UserPie graph sits at 100% used when there are a bunch of bonus
cores being used. try to fix this by adding to avail cores/nodes in
a similar way to how we add to used.
ie. if a job is using a core on a "bonus" node, then add that node to
the available count and add all the node's cores to available too.

on server side this is for history graph scaling (I think).
on client side it's for the UserPie.